### PR TITLE
delete_objects. copy_object: create the destination bucket if it does not exist.

### DIFF
--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"
   s.add_dependency "builder"
+  s.add_dependency "xml-simple"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -224,6 +224,23 @@ module FakeS3
       end
     end
 
+    def delete_objects(bucket, objects, request)
+      begin
+        filenames = []
+        objects.each do |object_name|
+          filenames << File.join(@root,bucket.name,object_name)
+          object = bucket.find(object_name)
+          bucket.remove(object)
+        end
+
+        FileUtils.rm_rf(filenames)
+      rescue
+        puts $!
+        $!.backtrace.each { |line| puts line }
+        return nil
+      end
+    end
+
     def create_metadata(content,request)
       metadata = {}
       metadata[:md5] = Digest::MD5.file(content).hexdigest

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -143,6 +143,11 @@ module FakeS3
       src_bucket = self.get_bucket(src_bucket_name)
       dst_bucket = self.get_bucket(dst_bucket_name)
 
+      if !dst_bucket
+        # Lazily create a bucket, the same way store_object does
+        dst_bucket = self.create_bucket(dst_bucket_name)
+      end
+
       obj = S3Object.new
       obj.name = dst_name
       obj.md5 = src_metadata[:md5]

--- a/lib/fakes3/xml_parser.rb
+++ b/lib/fakes3/xml_parser.rb
@@ -1,0 +1,16 @@
+require 'xmlsimple'
+
+module FakeS3
+  class XmlParser
+    def self.delete_objects(request)
+      keys = []
+
+      objects = XmlSimple.xml_in(request.body, {'NoAttr' => true})['Object']
+      objects.each do |key|
+        keys << key['Key'][0]
+      end
+
+      keys
+    end
+  end
+end


### PR DESCRIPTION
Following the same logic as the one that already exists for `store_object` - https://github.com/behance/fake-s3/blob/master/lib/fakes3/server.rb#L175

References for the multiple deletion: 

https://github.com/pola88/fake-s3/commit/8a8d2d58f175d91fdd66e1b896ae34bc4e84fc6c